### PR TITLE
Fix call to function that was renamed between agroce/echidna-parade and crytic/echidna-parade

### DIFF
--- a/echidna_parade/echidna.py
+++ b/echidna_parade/echidna.py
@@ -77,7 +77,7 @@ def generate_echidna_config(
     if (len(excluded) == len(public)) and (len(public) > 0):
         # This should be quite rare unless you have very few functions or a very low config.prob!
         print("Degenerate blacklist configuration, trying again...")
-        return generate_config(
+        return generate_echidna_config(
             rng, public, basic, bases, config, prefix, initial, coverage
         )
     new_config["filterFunctions"] = excluded


### PR DESCRIPTION
Fix call to function that was renamed from generate_config in agroce/echidna-parade to generate_echidna_config in crytic/echidna-parade

This call to an undefined function causes a crash when there is a degenerate blacklist configuration.

https://github.com/agroce/echidna-parade/blob/15c0dde0e6e25b0730fba992c89016db1fe717d9/echidna_parade/echidna_parade.py#L17
https://github.com/agroce/echidna-parade/blob/15c0dde0e6e25b0730fba992c89016db1fe717d9/echidna_parade/echidna_parade.py#L54

https://github.com/crytic/echidna-parade/blob/8c55b776f001d13bf400ec59883665df86efcaeb/echidna_parade/echidna.py#L30
https://github.com/crytic/echidna-parade/blob/8c55b776f001d13bf400ec59883665df86efcaeb/echidna_parade/echidna.py#L67